### PR TITLE
Replace data.page with current_page.data

### DIFF
--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -3,8 +3,8 @@
   %head
     %meta{:name => "viewport", :content => "width=device-width, initial-scale=1.0, maximum-scale=1.0 user-scalable=no"}
     %meta{:name => "charset", :content => "utf-8"}
-    %title= data.page.title || 'TryRuby'
-    %meta{:name => "description", :content => "#{data.page.description || 'Learn programming with Ruby'}"}
+    %title= current_page.data.title || 'TryRuby'
+    %meta{:name => "description", :content => "#{current_page.data.description || 'Learn programming with Ruby'}"}
 
     = stylesheet_link_tag 'vendor/bootstrap', media: 'all'
     = stylesheet_link_tag 'vendor/bootstrap-theme', media: 'all'


### PR DESCRIPTION
`data.page` seems to be broken. `current_page.data` is one of the replacement.
so I fixed.

ref: 
- https://github.com/middleman/middleman/issues/1397#issuecomment-61762634
- https://github.com/middleman/middleman-blog/issues/107#issuecomment-14944013
