### PR TITLE
Add comments to the Left Out article

### DIFF
--- a/source/articles/2015-01-05-what-i-left-out.html.markdown
+++ b/source/articles/2015-01-05-what-i-left-out.html.markdown
@@ -11,6 +11,23 @@ the_summary: TryRuby is a Ruby course for beginners. Its not possible to tell yo
 TryRuby is a Ruby course for beginners. Its not possible to tell you everything about Ruby in
 15 minutes. Here is an overview of some of the things that I have left out.
 
+### Comments
+To add text to your Ruby file, you can do so with comments. Comments can be used for
+documentation, explain parts of your code or anything else you'd like.
+
+Single line comments
+
+    # This is a 1 line comment
+    # Another comment here
+
+Multiline comments
+
+    puts "Hello World"
+    =begin
+    This comment can span multiple lines. You denote the beginning and end of the
+    comment with the keywods =begin and =end
+    =end
+
 ### Else-if
 There is an __elsif__ statement so you can do this:
 

--- a/source/articles/2015-01-05-what-i-left-out.html.markdown
+++ b/source/articles/2015-01-05-what-i-left-out.html.markdown
@@ -17,15 +17,15 @@ documentation, explain parts of your code or anything else you'd like.
 
 Single line comments
 
-    # This is a 1 line comment
-    # Another comment here
+    # A comment, this makes your code easier to read
+    x = 2 # comments can also be placed after a statement
 
 Multiline comments
 
     puts "Hello World"
     =begin
     This comment can span multiple lines. You denote the beginning and end of the
-    comment with the keywods =begin and =end
+    comment with the keywords =begin and =end at the start of separate newlines.
     =end
 
 ### Else-if


### PR DESCRIPTION
I thought the Try Ruby website was a good concise intro to Ruby's syntax. But I thought the additional article "What I’ve left out" was missing comments! I think this absolutely needs to be included.