### PR TITLE
fix typo puts count_plays

### DIFF
--- a/translations/ja/try_ruby_400.md
+++ b/translations/ja/try_ruby_400.md
@@ -29,8 +29,8 @@ selectメソッドから返ったリストを使い、__each__メソッドを呼
           puts val["title"]
         }.count
     end
-    
-    puts count_plays(0)
+
+    puts count_plays(1591)
 
 countメソッドをeachメソッドの終わりにつなげていることに気づきましたか？
 この値が__count\_plays__メソッドの戻り値になります。


### PR DESCRIPTION
puts count_playsが0なのでCopyボタンでRunを実行するとエラーになる事象を修正

Fixed an event that an error occurs when Run is executed with Copy button because puts count_plays is 0