### PR TITLE
Original CSS for each language

### DIFF
--- a/source/javascripts/try_ruby.js.rb
+++ b/source/javascripts/try_ruby.js.rb
@@ -138,6 +138,9 @@ class TryRuby
     # Update language select list
     Element.find('#tryruby-lang-select').value = language
 
+    # Update lang attribute
+    Element.find('html').attr('lang', language)
+
     language
   end
 
@@ -281,6 +284,7 @@ class TryRuby
   # Handle change language event
   def do_change_lang
     language = Element.find('#tryruby-lang-select').value
+    Element.find('html').attr('lang', language)
     set_cookie('tryruby_nl_language', language)
     get_content_from_server(language)
   end

--- a/source/layouts/layout.haml
+++ b/source/layouts/layout.haml
@@ -1,5 +1,5 @@
 !!!
-%html
+%html{:lang => "en"}
   %head
     %meta{:name => "viewport", :content => "width=device-width, initial-scale=1.0, maximum-scale=1.0 user-scalable=no"}
     %meta{:content => "text/html; charset=UTF-8", "http-equiv" => "Content-Type"}

--- a/source/stylesheets/application.css.scss
+++ b/source/stylesheets/application.css.scss
@@ -187,3 +187,5 @@ iframe {
   -webkit-transform-origin: 0 0;
   transform-origin: 0 0;
 }
+
+@import "languages/ja.css.scss";

--- a/source/stylesheets/languages/ja.css.scss
+++ b/source/stylesheets/languages/ja.css.scss
@@ -1,0 +1,24 @@
+:lang(ja) {
+  h2 {
+    font-size: 2.6rem;
+    line-height: 1.4;
+  }
+
+  h3 {
+    font-size: 2.0rem;
+    line-height: 1.4;
+  }
+
+  h4 {
+    font-size: 1.5rem;
+    line-height: 1.4;
+  }
+
+  #tryruby-content {
+    line-height: 1.86;
+
+    blockquote p {
+      line-height: 1.86;
+    }
+  }
+}


### PR DESCRIPTION
## Problem

CSS for English is hard to read in Japanese and right-to-left languages(Arabic and other).

Ref: #45

## Solution

I made it possible to switch `<html lang="ja">`.

You can now add language-specific CSS files.

For example: `source/stylesheets/languages/ja.css.scss`