### PR TITLE
Fix grammatical error in try_ruby_40.md

### DIFF
--- a/translations/en/try_ruby_40.md
+++ b/translations/en/try_ruby_40.md
@@ -13,7 +13,7 @@ What is going on?
 > output screen at the top. So when you type a formula you get to see the results.
 > __But only the last result.__ And only if the output is still empty.
 
-So when you entered 2 or more formula's, Ruby only showed the result of the last formula.
+So when you entered 2 or more formulas, Ruby only showed the result of the last formula.
 
 Of course you have the power to control the screen! Just type __puts__ before each formula
 (with a space in between). Puts means: *'put something on the screen'*.


### PR DESCRIPTION
The plural of `formula` is either `formulas` or `formulae`, not `formula's`.