### PR TITLE
Fix typo in en/try_ruby_310.md

### DIFF
--- a/translations/en/try_ruby_310.md
+++ b/translations/en/try_ruby_310.md
@@ -21,4 +21,4 @@ build a scorecard:
 __books.values.each { |rate| ratings[rate] += 1 }__
 
 ### Next
-In the next lesson we will delve al little bit deeper into methods.
+In the next lesson we will delve a little bit deeper into methods.


### PR DESCRIPTION
Hi folks, 

I noticed and fixed "delve al little bit deeper" to "delve a little bit deeper" - looks like a typo had left an `l` on the end of the "a" :)

Cheers
Caitlin