### PR TITLE
Fix spelling of the word 'output' in en/try_ruby_90.md

### DIFF
--- a/translations/en/try_ruby_90.md
+++ b/translations/en/try_ruby_90.md
@@ -10,7 +10,7 @@ error:
 Let's look at what you've learned in the first minute.
 
 ### The editor
-Typing code into the editor and clicking on run gives you an answer in the ouput window.
+Typing code into the editor and clicking on run gives you an answer in the output window.
 (Almost) all code gives an answer.
 
 ### Numbers and strings


### PR DESCRIPTION
Hey,

There was a small typo in the word `output` in `translations/en/try_ruby_90.md`

This merge request addresses this spelling mistake and aims to rectify it.