### PR TITLE
Replace opal-jquery with opal-browser

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 
 gem "opal", "~> 1.3"
 gem "opal-sprockets"
-gem "opal-jquery", ">= 0.4.6"
+gem "opal-browser"
 gem "middleman"
 gem "middleman-livereload"
 gem "middleman-syntax"
@@ -10,7 +10,7 @@ gem "middleman-sprockets"
 gem "middleman-blog"
 gem 'middleman-gh-pages'
 gem "redcarpet"
-gem 'haml'
-gem 'sass'
-gem 'webrick'
-gem 'terser'
+gem "haml"
+gem "sass"
+gem "webrick"
+gem "terser"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,11 +92,12 @@ GEM
       middleman-core (>= 3.2)
       rouge (~> 3.2)
     minitest (5.14.4)
-    opal (1.3.1)
+    opal (1.3.2)
       ast (>= 2.3.0)
       parser (~> 3.0)
-    opal-jquery (0.4.6)
-      opal (>= 0.10.0, < 2.0)
+    opal-browser (0.3.1)
+      opal (>= 1.0, < 2.0)
+      paggio (>= 0.3.0)
     opal-sprockets (1.0.2)
       opal (>= 1.0, < 2.0)
       sprockets (~> 4.0)
@@ -106,8 +107,9 @@ GEM
       padrino-support (= 0.15.1)
       tilt (>= 1.4.1, < 3)
     padrino-support (0.15.1)
+    paggio (0.3.0)
     parallel (1.21.0)
-    parser (3.0.2.0)
+    parser (3.0.3.0)
       ast (~> 2.4.1)
     parslet (2.0.0)
     public_suffix (4.0.6)
@@ -158,7 +160,7 @@ DEPENDENCIES
   middleman-sprockets
   middleman-syntax
   opal (~> 1.3)
-  opal-jquery (>= 0.4.6)
+  opal-browser
   opal-sprockets
   redcarpet
   sass
@@ -166,4 +168,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.2.15
+   2.2.28

--- a/source/index.html.markdown
+++ b/source/index.html.markdown
@@ -87,8 +87,3 @@ description: Learn to program in Ruby in 30 minutes
     </div>
   </div>
 </div>
-
-<script>
-Opal.loaded(OpalLoaded || []);
-Opal.require('try_ruby');
-</script>

--- a/source/index.html.markdown
+++ b/source/index.html.markdown
@@ -49,6 +49,8 @@ description: Learn to program in Ruby in 30 minutes
 
         <h3>Click on <strong>Next</strong> to start learning.</h3>
       </div>
+
+      <div id="tryruby-answer" style="display:none"></div>
     </div>
   </div>
 

--- a/source/index.html.markdown
+++ b/source/index.html.markdown
@@ -29,7 +29,7 @@ description: Learn to program in Ruby in 30 minutes
     </div>
 
     <select id="tryruby-index" class="form-control"></select>
-  
+
     <div id="tryruby-explanation">
 
       <h2 id="tryruby-title">Got 30 minutes? Give Ruby a shot right now!</h2>
@@ -38,7 +38,7 @@ description: Learn to program in Ruby in 30 minutes
         <p>Ruby is a programming language from Japan which is revolutionizing software development.</p>
         <p>The beauty of Ruby is found in its balance between simplicity and power.</p>
         <p>You can type some Ruby code in the editor and use these buttons to navigate:</p>
-        
+
         <ul>
           <li><strong>Run</strong> &rarr; Executes the code in the editor</li>
           <li><strong>Copy</strong> &rarr; Copies the example code to the editor</li>
@@ -49,9 +49,6 @@ description: Learn to program in Ruby in 30 minutes
 
         <h3>Click on <strong>Next</strong> to start learning.</h3>
       </div>
-
-      <div id="tryruby-answer" style="display:none"></div>
-
     </div>
   </div>
 

--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -1,1 +1,5 @@
 //= require try_ruby
+
+document.addEventListener("DOMContentLoaded", () => {
+  Opal.require("try_ruby");
+})

--- a/source/javascripts/application.js
+++ b/source/javascripts/application.js
@@ -1,5 +1,6 @@
 //= require try_ruby
 
 document.addEventListener("DOMContentLoaded", () => {
+  Opal.loaded(OpalLoaded || []);
   Opal.require("try_ruby");
 })

--- a/source/javascripts/try_ruby.js.rb
+++ b/source/javascripts/try_ruby.js.rb
@@ -5,6 +5,7 @@ require 'native'
 require 'promise'
 require 'browser/setup/full'
 require 'browser/cookies'
+require 'browser/form_data'
 
 # Container for individual lessons
 class TryRubyItem
@@ -334,9 +335,10 @@ class TryRuby
 
   # Playground methods
   def get_code_from_url
-    hash = $$.decodeURIComponent($$[:location][:hash].gsub('+', ' '))
+    hash = $document.location.fragment.to_s
+    hash = Browser::FormData.decode(hash.gsub('+', ' '))
 
-    hash['#code='.size..-1] if hash.start_with?('#code=')
+    hash.delete_prefix("#code=") if hash.start_with?('#code=')
   end
 
   def do_copy_url
@@ -381,7 +383,6 @@ class TryRuby
     @updating = true
     title_element.inner_html = item.title
     $document.at_css('#tryruby-content').inner_html = item.text
-    $document.at_css('#tryruby-answer').inner_html  = item.answer
     @editor.value = item.saved_editor if @editor
     @output.value = item.saved_output if @output
     @current_copycode = get_code_fragment(item.text)

--- a/source/javascripts/try_ruby.js.rb
+++ b/source/javascripts/try_ruby.js.rb
@@ -142,8 +142,7 @@ class TryRuby
     language = get_cookie('tryruby_nl_language')
 
     # No cookie -> user browser settings to determine language
-    if !language
-      # Only English for now. Uncomment lines to get browser setting
+    unless language
       browserlang = `navigator.languages ? navigator.languages[0] : (navigator.language || navigator.userLanguage || navigator.browserLanguage)`
       case browserlang.downcase
       when 'nl'
@@ -172,7 +171,7 @@ class TryRuby
     $document.at_css('#tryruby-lang-select').value = language
 
     # Update lang attribute
-    $document.at_css('html').attr('lang', language)
+    $document.root.attr('lang', language)
 
     language
   end
@@ -328,7 +327,7 @@ class TryRuby
   # Handle change language event
   def do_change_lang
     language = $document.at_css('#tryruby-lang-select').value
-    $document["html"]["lang"] = language
+    $document.root['lang'] = language
     set_cookie('tryruby_nl_language', language)
     get_content_from_server(language)
   end
@@ -346,11 +345,10 @@ class TryRuby
   end
 
   def gen_url
-    prefix = $$[:document][:location].toString.split("#").first
-    suffix = "#code=" + $$.encodeURIComponent(@editor.value)
-    suffix = suffix.gsub("%20", "+")
+    prefix = $document.location.uri.split("#").first
+    suffix = Browser::FormData.build_query(code: @editor.value).gsub("%20", "+")
 
-    prefix + suffix
+    "#{prefix}##{suffix}"
   end
 
   def on_hash_change
@@ -358,7 +356,7 @@ class TryRuby
   end
 
   def on_editor_change
-    $$[:window][:history].replaceState(nil, '', gen_url)
+    $window.history.replace(gen_url)
   end
   # End of playground methods
 
@@ -383,6 +381,7 @@ class TryRuby
     @updating = true
     title_element.inner_html = item.title
     $document.at_css('#tryruby-content').inner_html = item.text
+    $document.at_css('#tryruby-answer').inner_html = item.answer
     @editor.value = item.saved_editor if @editor
     @output.value = item.saved_output if @output
     @current_copycode = get_code_fragment(item.text)

--- a/source/javascripts/try_ruby.js.rb
+++ b/source/javascripts/try_ruby.js.rb
@@ -381,7 +381,7 @@ class TryRuby
     @updating = true
     title_element.inner_html = item.title
     $document.at_css('#tryruby-content').inner_html = item.text
-    $document.at_css('#tryruby-answer').inner_html = item.answer
+    $document.at_css('#tryruby-answer')&.inner_html = item.answer
     @editor.value = item.saved_editor if @editor
     @output.value = item.saved_output if @output
     @current_copycode = get_code_fragment(item.text)

--- a/source/playground.html.markdown
+++ b/source/playground.html.markdown
@@ -42,8 +42,3 @@ description: Play around with Ruby programs
     </div>
   </div>
 </div>
-
-<script>
-Opal.loaded(OpalLoaded || []);
-Opal.require('try_ruby');
-</script>


### PR DESCRIPTION
Hello TryRuby maintainers!

I’ve been trying to update to the latest jQuery & Bootstrap but found that `opal-jquery` had raised errors with them. Since there are only a few lines related to jQuery, we might as well switch to `opal-browser` to ease further updates.

Also, this PR refactors JS code a tiny bit and moves Opal loading to inside of `application.js`.