### PR TITLE
Update Opal to v1.4 in order to support Ruby 3.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem "opal", "~> 1.3"
+gem "opal", "~> 1.4a"
 gem "opal-sprockets"
 gem "opal-browser"
 gem "middleman"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -92,10 +92,10 @@ GEM
       middleman-core (>= 3.2)
       rouge (~> 3.2)
     minitest (5.14.4)
-    opal (1.3.2)
+    opal (1.4.0)
       ast (>= 2.3.0)
-      parser (~> 3.0)
-    opal-browser (0.3.2)
+      parser (~> 3.0, >= 3.0.3.2)
+    opal-browser (0.3.3)
       opal (>= 1.0, < 2.0)
       paggio (>= 0.3.0)
     opal-sprockets (1.0.2)
@@ -158,7 +158,7 @@ DEPENDENCIES
   middleman-livereload
   middleman-sprockets
   middleman-syntax
-  opal (~> 1.3)
+  opal (~> 1.4a)
   opal-browser
   opal-sprockets
   redcarpet


### PR DESCRIPTION
This fixes #106

This upgrades Opal to 1.4.0.alpha1. I tested it and it should be enough for now. It supports most of the new Ruby 3.1 features that make sense in a web browser.