### PR TITLE
Rescue `Exception` class to display all errors

### DIFF
--- a/source/javascripts/try_ruby.js.rb
+++ b/source/javascripts/try_ruby.js.rb
@@ -416,7 +416,7 @@ class TryRuby
       retval = `eval(js_code)`
       retval = retval ? retval.to_s : ''
       print_to_output(retval) if @output_buffer.length == 0 && !retval.empty?
-    rescue => err
+    rescue Exception => err
       error = err
       log_error(err)
     end


### PR DESCRIPTION
# Problem

Currently `eval_code` rescues `StandardError`, so it does not display `Exception`.

I realized this problem when I causes a `NotImplementedError`, which doesn't inherit `StandardError`.
Opal has not-implemented methods by design. For example, destructive methods for `String`. Some of these methods, such as `String#gsub!`, are popular, so the user may try to execute them.

However, currently `NotImplementedError` is not rescued, so it displays nothing if `NotImplementedError` occurs. I think it is confusing behavior.

# Solution

Rescue `Exception` to display all errors.


# Screenshots


before

![211226201425](https://user-images.githubusercontent.com/4361134/147406292-df1ac8a7-5b08-477a-a3b1-9ba552e234d1.png)



after

![211226201434](https://user-images.githubusercontent.com/4361134/147406293-e27d2f60-2de9-4eaf-9978-59bf0f904170.png)