### PR TITLE
Add CRuby engine option in playground

### DIFF
--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -41,6 +41,21 @@
       integrity="sha384-QJHtvGhmr9XOIpI6YVutG+2QOK9T+ZnN4kzFN1RtK3zEFEIsxhlmWl5/YESvpZ13"
       crossorigin="anonymous"
     ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/ruby-wasm-wasi@0.1.2/dist/index.umd.js"
+      integrity="sha256-cPmKu5S3jkz5j0NnceapOfiWkzhBQqiBovOLjeYXwA0="
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/@wasmer/wasmfs@0.12.0/lib/index.iife.js"
+      integrity="sha256-sOd4ekxVsN4PXhR+cn/4uNAxeQOJRcsaW5qalYfvkTw="
+      crossorigin="anonymous"
+    ></script>
+    <script
+      src="https://cdn.jsdelivr.net/npm/@wasmer/wasi@0.12.0/lib/index.iife.js"
+      integrity="sha256-FslFp/Vq4bDf2GXu+9QyBEDLtEWO3fkMjpyOaJMHJT8="
+      crossorigin="anonymous"
+    ></script>
     <%= javascript_include_tag "vendor/codemirror-compressed-4.8" %>
     <%= javascript_include_tag "application" %>
   </head>

--- a/source/playground.html.markdown
+++ b/source/playground.html.markdown
@@ -36,6 +36,13 @@ description: Play around with Ruby programs
         Copy URL
       </button>
 
+      <select
+        id="tryruby-engine"
+        class="form-select mx-3 w-50"
+        aria-controls="output"
+      >
+      </select>
+
       <button
         id="btn_run"
         type="button"


### PR DESCRIPTION
This PR adds a new Ruby executor option to run a given code by CRuby. This does not replace Opal at all, and it's one of the engine options.

I think this kind of option is useful to try some implementations of Ruby, but not friendly for those who are learning Ruby. So the option is shown only in the playground.

This PR uses the CRuby engine compiled to WebAssembly.

| Opal Engine | CRuby Engine |
| :-:|:-:|
| <img width="581" alt="Screen Shot 2022-02-17 at 15 45 03" src="https://user-images.githubusercontent.com/11702759/154421216-a3df2336-2429-41ef-a8e5-7349a81fafb9.png"> | <img width="577" alt="Screen Shot 2022-02-17 at 15 46 26" src="https://user-images.githubusercontent.com/11702759/154421292-69f60982-d722-4954-a0d8-98cc60219f6a.png">|