### PR TITLE
Replace iframe and links to to ruby-doc.org in Playground

### DIFF
--- a/source/playground.html.markdown
+++ b/source/playground.html.markdown
@@ -9,14 +9,14 @@ description: Play around with Ruby programs
     <div id="tryruby-content">
       <div class="playground-iframe-wrapper">
         <iframe
-          src="https://www.ruby-doc.org/core/Kernel.html"
-        >www.ruby-doc.org</iframe>
+          src="https://docs.ruby-lang.org/en/master/"
+        >Ruby Documentation</iframe>
       </div>
 
       <p>
         In the Playground you can try any Ruby code you like.<br />
         The
-        <a href="https://www.ruby-doc.org/core/Kernel.html" target="_blank">Ruby documentation</a>
+        <a href="https://docs.ruby-lang.org/en/master/" target="_blank">Official Ruby documentation</a>
         is included.
       </p>
     </div>


### PR DESCRIPTION
I was excited to check out the new WASM Try Ruby playground today and fell on this iframe embed of the ruby-doc.org website which is not at all an official Ruby documentation site but a third-party ad-supported site that as far as I know isn't controlled or sanctioned by Ruby core. 

<img width="1284" alt="image" src="https://user-images.githubusercontent.com/65950/162335277-5eddfeb7-6953-47ee-a2a7-3490b13055e7.png">

Worse, the console showed me the site was trying to load ads from Carbon and BuySellAds. There's an even more malicious looking attempt that was thankfully blocked as well.

<img width="482" alt="image" src="https://user-images.githubusercontent.com/65950/162335348-08d0054b-06b0-4338-81f5-6c9320990d95.png">

While https://docs.ruby-lang.org is not well ranked in search engines or well know, it's the only official host of Ruby documentation and it can't be hijacked by random folks to serve ads or potentially much more malicious content to unsuspecting folks looking at the Try Ruby playground.

This PR replaces the iframe embed and links to point to docs.ruby-lang.org