### PR TITLE
Fix loading code from URI

### DIFF
--- a/source/javascripts/try_ruby.js.rb
+++ b/source/javascripts/try_ruby.js.rb
@@ -468,7 +468,7 @@ class TryRuby
 
   # Playground methods
   def get_state_from_url
-    hash = $document.location.fragment.to_s
+    hash = $document.location.fragment.to_s.delete_prefix('#')
     hash = Browser::FormData.parse_query(hash.gsub('+', ' '))
     [hash['code'], hash['engine']]
   end

--- a/spec/playground_spec.rb
+++ b/spec/playground_spec.rb
@@ -1,61 +1,87 @@
 require_relative "tryruby_helpers"
 
 RSpec.describe "Playground", type: :feature, js: true do
-  before :each do
-    visit "/playground"
-  end
-
-  playground_test = -> msg, result, ruby do
-    it msg do
-      set_code ruby
-      click_button "Run"
-      code(:output).chomp.should be == result
-    end
-  end
-
-  playground_test.call "should be able to evaluate simple Ruby code", "6", <<~RUBY
-    def test
-      2
+  context "compatibility" do
+    before :each do
+      visit "/playground"
     end
 
-    test + test * test
-  RUBY
-
-  playground_test.call "should support flip-flops", (50..55).to_a.join("\n"), <<~RUBY
-    (1..100).each do |i|
-      if (i == 50) .. (i == 55)
-        puts i
+    playground_test = -> msg, result, ruby do
+      it msg do
+        set_code ruby
+        click_button "Run"
+        code(:output).chomp.should be == result
       end
     end
-  RUBY
 
-  playground_test.call "should support pattern matching", "6", <<~RUBY
-    {a: 6, b: 7} => {a:}
-    puts a
-  RUBY
+    playground_test.call "should be able to evaluate simple Ruby code", "6", <<~RUBY
+      def test
+        2
+      end
 
-  playground_test.call "should support classes, modules and refinements", "123", <<~RUBY
-    module M
-      def m = 3
-    end
+      test + test * test
+    RUBY
 
-    class A
-      include M
-      def m = super + 20
-    end
+    playground_test.call "should support flip-flops", (50..55).to_a.join("\n"), <<~RUBY
+      (1..100).each do |i|
+        if (i == 50) .. (i == 55)
+          puts i
+        end
+      end
+    RUBY
 
-    class B < A
-      def m = super + 50
-    end
+    playground_test.call "should support pattern matching", "6", <<~RUBY
+      {a: 6, b: 7} => {a:}
+      puts a
+    RUBY
 
-    module R
-      refine B do
+    playground_test.call "should support classes, modules and refinements", "123", <<~RUBY
+      module M
+        def m = 3
+      end
+
+      class A
+        include M
+        def m = super + 20
+      end
+
+      class B < A
         def m = super + 50
       end
+
+      module R
+        refine B do
+          def m = super + 50
+        end
+      end
+
+      using R
+
+      B.new.m
+    RUBY
+  end
+
+  context "should update the textfield on hash code update" do
+    it "on the first load" do
+      visit "/playground#code=1"
+      code(:editor).should be == "1"
     end
 
-    using R
+    it "on the further load" do
+      visit "/playground"
+      visit "/playground#code=2"
+      code(:editor).should be == "2"
+    end
 
-    B.new.m
-  RUBY
+    it "on the first load with engine selected" do
+      visit "/playground#code=3&engine=opal"
+      code(:editor).should be == "3"
+    end
+
+    it "on the further load with engine selected" do
+      visit "/playground"
+      visit "/playground#code=4&engine=opal"
+      code(:editor).should be == "4"
+    end
+  end
 end


### PR DESCRIPTION
Previously, if you hit the "Copy URL" button and visit the URL in a different tab, you would not get the code that you had in the editor. For example, try https://try.ruby-lang.org/playground/#code=no&engine=cruby-3.2.0dev
I see the default code snippet in the editor when the url is supposed to encode "no".

Additionally, if you edit the code in the URL and hit enter, you'd get a error in the JS console.

Both of these issue were caused by getting a string back that start with a '#'. Delete this prefix.

cc @hmdne 