### PR TITLE
Use GitHub Pages Actions instead of gh-pages branch deployment.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,30 +1,47 @@
-name: Build and Deploy
+name: Deploy middleman site to Pages
 
 on:
   push:
     branches:
       - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
         with:
-          persist-credentials: false
-      - uses: ruby/setup-ruby@v1
-        with:
-          ruby-version: "3.0"
-      - name: Install dependencies
-        run: |
-          gem install bundler -v 2.1.4
-          bundle install
-      - name: Build
-        run: bin/middleman build
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
-        with:
-          github_token: ${{ secrets.ACCESS_TOKEN }}
-          publish_dir: ./build
-          cname: try.ruby-lang.org
+          ruby-version: '3.2'
+          bundler-cache: true
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build with middleman
+        # Outputs to the './_site' directory by default
+        run: bundle exec middleman build
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v1

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build/*
+_site/*
 .bundle
 .idea
 .ruby-version

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     mini_portile2 (2.8.1)
     minitest (5.17.0)
     nio4r (2.5.8)
-    nokogiri (1.13.10)
+    nokogiri (1.14.2)
       mini_portile2 (~> 2.8.0)
       racc (~> 1.4)
     opal (1.7.1)

--- a/config.rb
+++ b/config.rb
@@ -28,6 +28,7 @@ end
 
 activate :directory_indexes
 
+set :build_dir, '_site' # for GitHub Pages
 set :css_dir, 'stylesheets'
 set :js_dir, 'javascripts'
 


### PR DESCRIPTION
https://github.blog/2022-08-10-github-pages-now-uses-actions-by-default/

GitHub changes to default deployment workflow used by GitHub Actions. I migrate it from `gh-pages` branch deployment.