### PR TITLE
Hotfix broken integration test for playground

### DIFF
--- a/app/ruby_engine.rb
+++ b/app/ruby_engine.rb
@@ -35,10 +35,12 @@ class RubyEngine
       "https://cdn.jsdelivr.net/npm/ruby-head-wasm-wasi@0.5.0-2022-12-25-a/dist/ruby.wasm",
       "3.2.0"
     ),
-    CRubyWASI.new(
-      "https://cdn.jsdelivr.net/npm/ruby-head-wasm-wasi@next/dist/ruby.wasm",
-      "3.3.0dev"
-    ),
+    # FIXME(katei): Head build is no longer compatible with ruby-head-wasm-wasi@0.5.0,
+    # so we should have a worker for each version of CRuby to load corresponding ruby-*-wasm-wasi
+    # CRubyWASI.new(
+    #   "https://cdn.jsdelivr.net/npm/ruby-head-wasm-wasi@next/dist/ruby.wasm",
+    #   "3.3.0dev"
+    # ),
   ].each_with_object({}) do |engine, hash|
     hash[engine.engine_id] = engine
   end

--- a/spec/playground_spec.rb
+++ b/spec/playground_spec.rb
@@ -2,7 +2,7 @@ require_relative "tryruby_helpers"
 
 RSpec.describe "Playground", type: :feature, js: true do
   context "engine" do
-    engines = ["opal-ww-1.7.1", "cruby-3.2.0", "cruby-3.3.0dev"]
+    engines = ["opal-ww-1.7.1", "cruby-3.2.0"]
     engines.each do |engine|
       context engine do
         before :each do


### PR DESCRIPTION
The playground engines load multiple versions of ruby binary, but they uses the same ruby-head-wasm-wasi version for them. The latest `@next` version of ruby binary is no longer compatible with the older one, so raised the following exception:

```
WebAssembly.instantiate(): Import #6 module=\"rb-js-abi-host\" function=\"float-to-js-number...(value: float64) -> handle<js-abi-value>\" error: function import requires a callable (Exception)
```

This is just a hotfix to unblock the CI for now. Follow-up fix will be made soon.