### PR TITLE
Remove inaccurate mention of editor position in try_ruby_20

### DIFF
--- a/translations/en/try_ruby_20.md
+++ b/translations/en/try_ruby_20.md
@@ -6,7 +6,7 @@ ok:     Good! You did a bit of math. See how the answer popped out?
 error:  Type 2 + 6 in the editor
 ---
 
-The editor window at the bottom is where you type your Ruby code, hit the __Run__ button and
+The editor window is where you type your Ruby code. Hit the __Run__ button and
 watch it run!
 
 For example, try typing some math. Like:


### PR DESCRIPTION
Resolves https://github.com/ruby/TryRuby/issues/126. I've also made a small improvement to the grammar