### PR TITLE
Remove inaccurate mention of output position in try_ruby_40

### DIFF
--- a/translations/en/try_ruby_40.md
+++ b/translations/en/try_ruby_40.md
@@ -10,7 +10,7 @@ Did you notice that if you typed more than one formula you only saw the answer f
 What is going on?
 
 > To make this website easier to use I have told Ruby to copy the result of your program to the
-> output screen at the top. So when you type a formula you get to see the results.
+> output screen. So when you type a formula you get to see the results.
 > __But only the last result.__ And only if the output is still empty.
 
 So when you entered 2 or more formulas, Ruby only showed the result of the last formula.


### PR DESCRIPTION
Complements https://github.com/ruby/TryRuby/pull/160. Related: https://github.com/ruby/TryRuby/issues/126. On a maximised desktop browser, the output is on the bottom:

![image](https://github.com/ruby/TryRuby/assets/2916331/9eeb5954-d6d2-4cf7-baa5-5e46ff05f612)
