### PR TITLE
Prevent nil exceptions in helper.rb under exceptionally unusual conditions

### DIFF
--- a/app/helper.rb
+++ b/app/helper.rb
@@ -4,10 +4,10 @@ class Helper
   @@navigator = $window&.navigator
 
   def self.ios?
-    @@navigator.user_agent&.match?(/\b(iPad|iPhone|iPod)\b/) || false
+    @@navigator&.user_agent&.match?(/\b(iPad|iPhone|iPod)\b/) || false
   end
 
   def self.macos?
-    @@navigator.user_agent&.match?(/\bMac\b/) || false
+    @@navigator&.user_agent&.match?(/\bMac\b/) || false
   end
 end


### PR DESCRIPTION
Under normal conditions, the current code works as intended. However, in certain exceptionally unusual environments, nil exceptions can occur. This PR prevents those exceptions from happening.