### PR TITLE
CRuby 3.3 by default on Try Ruby

### DIFF
--- a/app/try_ruby.rb
+++ b/app/try_ruby.rb
@@ -15,7 +15,7 @@ class TryRuby
   RUBY
   INITIAL_TRY_RESULT = 'Welcome ' * 3
 
-  DEFAULT_RUBY_ENGINE = "cruby-3.2.2"
+  DEFAULT_RUBY_ENGINE = "cruby-3.3.0"
 
   def self.start
     instance


### PR DESCRIPTION
Follow up https://github.com/ruby/TryRuby/pull/189.

Currently, the default Ruby engine for the Playground is CRuby 3.2. https://try.ruby-lang.org/playground/

As a result, Try Ruby handles with CRuby 3.2.
https://try.ruby-lang.org/

This PR updates the default to CRuby 3.3, allowing Try Ruby to run in the latest available Ruby environment in browser.
The current Ruby version is 3.4, but the `@ruby/3.4-wasm-wasi` has not yet been released. Therefore, CRuby 3.3, the latest version available for wasm, is used.

This issue has been reported in the following issue and can be addressed independently:
https://github.com/ruby/ruby.wasm/issues/567