### PR TITLE
Sort CRuby engines by version in the Playground.

### DIFF
--- a/app/ruby_engine.rb
+++ b/app/ruby_engine.rb
@@ -39,15 +39,15 @@ class RubyEngine
   # When you update the engines, ensure that they are tested correctly.
   # Update the engine list also in spec/playground_spec.
   ENGINES = [
-    # https://www.jsdelivr.com/package/npm/@ruby/3.2-wasm-wasi?tab=files&path=dist&version=2.4.1
-    CRubyWASI.new(
-      "https://cdn.jsdelivr.net/npm/@ruby/3.2-wasm-wasi@2.4.1/dist/ruby.wasm",
-      "3.2.2"
-    ),
     # https://www.jsdelivr.com/package/npm/@ruby/3.3-wasm-wasi?tab=files&path=dist&version=2.4.1
     CRubyWASI.new(
       "https://cdn.jsdelivr.net/npm/@ruby/3.3-wasm-wasi@2.4.1/dist/ruby.wasm",
       "3.3.0"
+    ),
+    # https://www.jsdelivr.com/package/npm/@ruby/3.2-wasm-wasi?tab=files&path=dist&version=2.4.1
+    CRubyWASI.new(
+      "https://cdn.jsdelivr.net/npm/@ruby/3.2-wasm-wasi@2.4.1/dist/ruby.wasm",
+      "3.2.2"
     ),
     # Opal.new,
     OpalWebWorker.new("1.7.1"),


### PR DESCRIPTION
This was noticed during #191.

It would be preferable for newer CRuby engines, which allow the use of new features, to appear more prominently at the top of the dropdown in the Playground.
https://try.ruby-lang.org/playground/

This PR rearranges the list to prioritize and highlight the newer CRuby engine.