### PR TITLE
French translation: correct error and add shortcut

### DIFF
--- a/translations/fr/try_ruby_280.md
+++ b/translations/fr/try_ruby_280.md
@@ -19,7 +19,7 @@ Desormais, nous allons compter tes critiques. Reste avec moi. Écris :
     
     puts notations
 
-La trait droite dans le code est le caractère pipe (|), probablement situé juste au-dessus de la touche 'T' OU 'Y' d'un clavier Windows Français.
+Le trait droit dans le code correspond au caractère "pipe" (|), probablement situé juste au-dessus de la touche 'T' OU 'Y' d'un clavier Windows Français, ou "Option+Maj+L" sur MacOS.
 
 Le _+= 1_ signifie : augmenter la valeur de 1.
 

--- a/translations/fr/try_ruby_390.md
+++ b/translations/fr/try_ruby_390.md
@@ -7,52 +7,6 @@ error:
 load:   prev
 ---
 
-Okay we now have a list of plays from the internet. The list was in the json format.
-Fortunately for us Ruby kindly provides a method to convert json data to a Ruby hash.
-The _get\_shakey_ method already did that for us.
-
-But since the structure of the json data is retained in the hash, it is still a bit difficult to read.
-Let us write a method to display the plays nicely.
-
-If you inspect the list of plays carefully you will see that it has a kind of nested
-structure. (This is actually quite common in data you get from the internet.)
-Looks like this:
-
-<ul>
-  <li>"William Shakespeare"
-  <ul>
-      <li>"1"
-      <ul>
-        <li>"title": "The Two Gentlemen of Verona"</li>
-        <li>"finished": 1591</li>
-      </ul>
-      </li>
-      <li>"2"
-      <ul>
-        <li>"title": "The Taming of the Shrew"</li>
-        <li>"finished": 1591</li>
-      </ul>
-      </li>
-      <li>...</li>
-  </ul>
-  </li>
-</ul>
-
-To list the plays we first have to access the top "William Shakespeare" hash element by its name.
-Next we have to __iterate__ through each element below it.
-
-Ruby has a method for iterating. It is called __each__. We have seen it before when
-creating our book rating system.
-
-Everything that method __each__ returns is passed to a block:
-
-    s = get_shakey
-    
-    s["William Shakespeare"].each { |key, val|
-      puts val["title"]
-    }
-
-
 Bien, maintenant nous avons une liste de pièces de théâtre provenant d'Internet. La liste est au format json.
 Heureusement pour nous, Ruby fournit gentiment une méthode pour convertir les données json en un hash Ruby.
 La méthode _get\_shakey_ l'a déjà fait pour nous.

--- a/translations/fr/try_ruby_460.md
+++ b/translations/fr/try_ruby_460.md
@@ -16,7 +16,7 @@ Tu viens juste d'avoir une idée brillante pour une nouvelle application.
 Ce sera __LA__ prochaine plateforme de messagerie instantanée.
 Tu veux une application où les gens peuvent s'envoyer des messages courts.
 Tu appelles ces messages Blurbs<sup>TM</sup>. Un Blurb<sup>TM</sup> a une longueur maximale de seulement 40 caractères.
-Ajoutons également definir son humeur (__mood__).
+Ajoutons également la possibilité de définir son humeur (__mood__).
 
 ### Par où commencer
 Eh bien, tu pourrais stocker tes entrées Blurbs<sup>TM</sup> dans un fichier json, n'est-ce pas ?


### PR DESCRIPTION
Correct "La trait" with "Le trait" which is the correct form in french. 

Added the not so intuitive shortcut on macos azerty keyboard. 