### PR TITLE
Fix a deprecated message about `url_blacklist`

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,11 +33,10 @@ RSpec.configure do |config|
       inspector: ENV['INSPECTOR'],
       headless: !ENV['NO_HEADLESS'],
       timeout: 20,
-      url_blacklist: [
-        "https://docs.ruby-lang.org/", # It is quite a heavy website iframed on playground
-                                      # and for testing, we don't need it to be present.
-                                      # This should spare us from random test failures.
-      ],
+      # It is quite a heavy website iframed on playground
+      # and for testing, we don't need it to be present.
+      # This should spare us from random test failures.
+      url_blocklist: %r{https://docs.ruby-lang.org/},
     )
   end
 


### PR DESCRIPTION
Passing strings to blacklist/whitelist is deprecated. This PR fixes it to remove deprecate messages.
https://github.com/ruby/TryRuby/actions/runs/14211217635/job/39818646230#step:4:47 https://github.com/rubycdp/cuprite/blob/4fa812640823e160cb359f40291fe8cf88e05cca/lib/capybara/cuprite/browser.rb#L251

Also, the config name is `url_blocklist` now.
https://github.com/rubycdp/cuprite?tab=readme-ov-file#url-blocklisting--allowlisting

The old name can be used for backward compatibility. But I think there is no reason to use the old one. So this PR also changed the name to the new one.