### PR TITLE
Fix blurb2 variable

### DIFF
--- a/translations/de/try_ruby_510.md
+++ b/translations/de/try_ruby_510.md
@@ -3,11 +3,11 @@ lang:   DE
 title:  Du hast deiner App beigebracht, wertlose Dinge abzulehnen
 answer: Blurb:
 ok:     Blurb hinzugefügt
-error:  
+error:
 load:   class Blurb;attr_accessor :content,:time,:mood;def initialize(mood, content="");@time=Time.now;@content=content[0..39];@mood=mood;end;end;blurb1=Blurb.new(:sick,"Today Mount Hood Was Stolen!")
 ---
 
-Hast du gesehen, wie wir innerhalb der Klasse die at-Symbole (@time) verwendet 
+Hast du gesehen, wie wir innerhalb der Klasse die at-Symbole (@time) verwendet
 haben?
 
 __Außerhalb__ der Klasse verwenden wir Accessors:
@@ -18,13 +18,13 @@ aber __innerhalb__ verwenden wir die __Objektvariablen__:
 
 > __@time = Time.now__
 
-Sie sind genau dasselbe, werden aber an zwei verschiedenen Stellen in deinem 
+Sie sind genau dasselbe, werden aber an zwei verschiedenen Stellen in deinem
 Programm verwendet.
 
 ### Erstelle einen weiteren Blurb<sup>TM</sup>
-Wenn ein neuer Blurb<sup>TM</sup> erstellt wird, überprüft die Methode 
+Wenn ein neuer Blurb<sup>TM</sup> erstellt wird, überprüft die Methode
 initialize, ob irgendwelche Argumente für new gibt.
 
 Äh, wir brauchen zwei Argumente:
 
-    Blurb2 = Blurb.new :confused, "I can not believe Mt. Hood was stolen!"
+    blurb2 = Blurb.new :confused, "I can not believe Mt. Hood was stolen!"

--- a/translations/en/try_ruby_510.md
+++ b/translations/en/try_ruby_510.md
@@ -3,7 +3,7 @@ lang:   EN
 title:  You've Taught Your App to Reject Worthless Things
 answer: Blurb:
 ok:     Blurb added
-error:  
+error:
 load:   class Blurb;attr_accessor :content,:time,:mood;def initialize(mood, content="");@time=Time.now;@content=content[0..39];@mood=mood;end;end;blurb1=Blurb.new(:sick,"Today Mount Hood Was Stolen!")
 ---
 
@@ -25,4 +25,4 @@ arguments to new.
 
 Uh, we need two arguments:
 
-    Blurb2 = Blurb.new :confused, "I can not believe Mt. Hood was stolen!"
+    blurb2 = Blurb.new :confused, "I can not believe Mt. Hood was stolen!"

--- a/translations/es/try_ruby_510.md
+++ b/translations/es/try_ruby_510.md
@@ -3,7 +3,7 @@ lang:   ES
 title:  Has Enseñado a tu Aplicación a Rechazar Cosas Sin Valor
 answer: Blurb:
 ok:     Blurb añadido
-error:  
+error:
 load:   class Blurb;attr_accessor :contenido,:tiempo,:animo;def initialize(animo, contenido="");@tiempo=Time.now;@contenido=contenido[0..39];@animo=animo;end;end;blurb1=Blurb.new(:enfermo,"¡El Everest ha sido robado!")
 ---
 
@@ -24,4 +24,4 @@ Cuando se crea un nuevo Blurb<sup>TM</sup>, se usa el método initialize para ch
 
 Eh, necesitamos dos argumentos:
 
-    Blurb2 = Blurb.new :confuso, "¡No puedo creer que hayan robado el Everest!"
+    blurb2 = Blurb.new :confuso, "¡No puedo creer que hayan robado el Everest!"

--- a/translations/fr/try_ruby_510.md
+++ b/translations/fr/try_ruby_510.md
@@ -25,4 +25,4 @@ arguments à new.
 
 Nous avons besoin de deux arguments :
 
-    Blurb2 = Blurb.new :confus, "Je ne peux pas croire que le Mont Blanc a été volé !"
+    blurb2 = Blurb.new :confus, "Je ne peux pas croire que le Mont Blanc a été volé !"

--- a/translations/ja/try_ruby_510.md
+++ b/translations/ja/try_ruby_510.md
@@ -3,7 +3,7 @@ lang:   JA
 title:  意味ないものは拒むようにしつけました
 answer: Blurb:
 ok:     Blurbが追加されました
-error:  
+error:
 load:   class Blurb;attr_accessor :content,:time,:mood;def initialize(mood, content="");@time=Time.now;@content=content[0..39];@mood=mood;end;end;blurb1=Blurb.new(:sick,"Today Mount Hood Was Stolen!")
 ---
 
@@ -24,4 +24,4 @@ load:   class Blurb;attr_accessor :content,:time,:mood;def initialize(mood, cont
 
 あ、2つの引数が必要です。
 
-    Blurb2 = Blurb.new :confused, "I can not believe Mt. Hood was stolen!"
+    blurb2 = Blurb.new :confused, "I can not believe Mt. Hood was stolen!"

--- a/translations/mk/try_ruby_510.md
+++ b/translations/mk/try_ruby_510.md
@@ -3,7 +3,7 @@ lang:   МК
 title:  Ти ја научи апликацијата да ги одбива непотребните работи
 answer: Blurb:
 ok:     Blurb е додаден
-error:  
+error:
 load:   class Blurb;attr_accessor :content,:time,:mood;def initialize(mood, content="");@time=Time.now;@content=content[0..39];@mood=mood;end;end;blurb1=Blurb.new(:sick,"Today Mount Hood Was Stolen!")
 ---
 
@@ -24,4 +24,4 @@ __Надвор__ од класата, ние искористивме accessors:
 
 Во овој случај, нам ни требаат два параметри:
 
-    Blurb2 = Blurb.new :confused, "I can not believe Mt. Hood was stolen!"
+    blurb2 = Blurb.new :confused, "I can not believe Mt. Hood was stolen!"

--- a/translations/pt-br/try_ruby_510.md
+++ b/translations/pt-br/try_ruby_510.md
@@ -3,7 +3,7 @@ lang:   PT-BR
 title:  Você Ensinou Seu App a Desprezar Coisas Sem Valor
 answer: Blurb:
 ok:     Blurb adicionado
-error:  
+error:
 load:   class Blurb;attr_accessor :conteudo,:tempo,:humor;def initialize(humor, conteudo="");@tempo=Time.now;@conteudo=conteudo[0..39];@humor=humor;end;end;blurb1=Blurb.new(:doente,"Hoje, Mount Hood foi roubado!")
 ---
 
@@ -25,4 +25,4 @@ por algum argumento para o new.
 
 Uh, nós precisamos de dois argumentos:
 
-    Blurb2 = Blurb.new :confuso, "Eu não posso acreditar que Mt. Hood foi roubado!"
+    blurb2 = Blurb.new :confuso, "Eu não posso acreditar que Mt. Hood foi roubado!"

--- a/translations/tr/try_ruby_510.md
+++ b/translations/tr/try_ruby_510.md
@@ -3,7 +3,7 @@ lang:   TR
 title:  Aplikasyonuna Değersiz Şeyleri Reddetmeyi Öğrettin
 answer: Blurb:
 ok:     Blurb eklendi
-error:  
+error:
 load:   class Blurb;attr_accessor :content,:time,:mood;def initialize(mood, content="");@time=Time.now;@content=content[0..39];@mood=mood;end;end;blurb1=Blurb.new(:sick,"Today Mount Hood Was Stolen!")
 ---
 
@@ -13,7 +13,7 @@ Class __dışarısında__ accessor'lar kullanıyoruz:
 
 > __blurb.time = Time.now__
 
-ancak __içeride__ kullandıklarımızsa __objenin değişkenleri__: 
+ancak __içeride__ kullandıklarımızsa __objenin değişkenleri__:
 
 > __@time = Time.now__
 
@@ -25,4 +25,4 @@ kontrol etmek için çalıştırılır.
 
 Uh, iki argümana ihtiyacımız var:
 
-    Blurb2 = Blurb.new :confused, "I can not believe Mt. Hood was stolen!"
+    blurb2 = Blurb.new :confused, "I can not believe Mt. Hood was stolen!"

--- a/translations/ua/try_ruby_510.md
+++ b/translations/ua/try_ruby_510.md
@@ -3,7 +3,7 @@ lang:   UA
 title:  Ти навчив свій додаток відкидати непотрібні речі
 answer: Blurb:
 ok:     Blurb додано
-error:  
+error:
 load:   class Blurb;attr_accessor :content,:time,:mood;def initialize(mood, content="");@time=Time.now;@content=content[0..39];@mood=mood;end;end;blurb1=Blurb.new(:sick,"Today Mount Hood Was Stolen!")
 ---
 
@@ -24,4 +24,4 @@ __Ззовні__ класу ми використовуємо аксесор:
 
 Ой, потрібно ще 2 аргументи:
 
-    Blurb2 = Blurb.new :confused, "Не можу повірити, Мавнт-Худ вкрали!"
+    blurb2 = Blurb.new :confused, "Не можу повірити, Мавнт-Худ вкрали!"

--- a/translations/zh/try_ruby_510.md
+++ b/translations/zh/try_ruby_510.md
@@ -3,7 +3,7 @@ lang:   ZH
 title:  你教会了你的app拒绝做无意义的事
 answer: Blurb:
 ok:     Blurb已添加
-error:  
+error:
 load:   class Blurb;attr_accessor :content,:time,:mood;def initialize(mood, content="");@time=Time.now;@content=content[0..39];@mood=mood;end;end;blurb1=Blurb.new(:sick,"Today Mount Hood Was Stolen!")
 ---
 
@@ -24,4 +24,4 @@ They're the exact same thing, but expressed in two different places of your prog
 
 额，我们需要两个新参数:
 
-    Blurb2 = Blurb.new :confused, "I can not believe Mt. Hood was stolen!"
+    blurb2 = Blurb.new :confused, "I can not believe Mt. Hood was stolen!"


### PR DESCRIPTION
In lesson « You've Taught Your App to Reject Worthless Things » the example gives an incorrect constant for `blurb2`:

<img width="1325" height="318" alt="Screenshot of lesson showing the example is Blurb2 instead of blurb2" src="https://github.com/user-attachments/assets/4b7a7af3-5417-4f71-a268-49a3c6ff2871" />

This fixes it so that the variable keeps the correct variable name of `blurb2` instead of `Blurb2`, as used in the next lesson.

```md
load:   prev;blurb2=Blurb.new :confused, "I can not believe Mt. Hood was stolen!"
```