### PR TITLE
Fix warnings related with Opal 2

### DIFF
--- a/app/editor.rb
+++ b/app/editor.rb
@@ -1,3 +1,5 @@
+# backtick_javascript: true
+
 # Wrapper for CodeMirror objects
 class Editor
   def initialize(dom_id, options)

--- a/app/ruby_engine/cruby_wasi.rb
+++ b/app/ruby_engine/cruby_wasi.rb
@@ -1,4 +1,5 @@
 # await: *await*, loading
+# backtick_javascript: true
 
 require 'await'
 

--- a/app/ruby_engine/opal_webworker.rb
+++ b/app/ruby_engine/opal_webworker.rb
@@ -1,4 +1,5 @@
 # await: *await*, loading
+# backtick_javascript: true
 
 require 'base64'
 require 'json'

--- a/app/try_ruby.rb
+++ b/app/try_ruby.rb
@@ -1,4 +1,5 @@
 # await: true
+# backtick_javascript: true
 
 require 'dependencies'
 require 'editor'


### PR DESCRIPTION
Currently, some codes output warnings like the following.

```
warning: Backtick operator usage interpreted as intent to embed JavaScript; this code will break in Opal 2.0; add a magic comment: `# backtick_javascript: true` -- ./try_ruby.rb:
```
https://github.com/ruby/TryRuby/actions/runs/17408494030/job/49419277575#step:4:8

In Opal 2, `backtick_javascript` defaults to false, because `Kernel#backtick` is implemented. Files using inline JavaScript must add the `# backtick_javascript: true` magic comment.

Ref: https://github.com/opal/opal/pull/2746